### PR TITLE
Add Database Template in Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ logging.handlers.console:
   stream: ext://sys.stdout
 logging.loggers.InstaBot.handlers:
   - console
+database.type: "sql"
+database.path: '/app/db/{{login}}.db'
+database.connection_string: 'sqlite:///{{database.path}}'
 start_at_h: 0
 start_at_m: 0
 end_at_h: 23

--- a/config/instabot.config.yml
+++ b/config/instabot.config.yml
@@ -12,6 +12,9 @@ logging.handlers.console:
   stream: ext://sys.stdout
 logging.loggers.InstaBot.handlers:
   - console
+database.type: "sql"
+database.path: '/app/db/{{login}}.db'
+database.connection_string: 'sqlite:///{{database.path}}'
 start_at_h: 0
 start_at_m: 0
 end_at_h: 23


### PR DESCRIPTION
It seems like `instabot.py` doesn't accept SQL configuration through the command line parameter anymore. They moved it to the config file.